### PR TITLE
monit: Add testing to CMake

### DIFF
--- a/monitoring-server/CMakeLists.txt
+++ b/monitoring-server/CMakeLists.txt
@@ -20,6 +20,9 @@ enable_sanitizers(project_options)
 ## Add static analyzers
 include(cmake/StaticAnalyzers.cmake)
 
+## Add testing
+include(cmake/Testing.cmake)
+
 ## Add project
 add_library(docs INTERFACE)
 include(cmake/Project.cmake)

--- a/monitoring-server/cmake/Project.cmake
+++ b/monitoring-server/cmake/Project.cmake
@@ -34,5 +34,7 @@ target_include_directories(Core
 
 target_include_directories(docs INTERFACE include)
 
+add_subdirectory(tests)
+
 add_subdirectory(libs)
 add_subdirectory(platforms)

--- a/monitoring-server/cmake/Testing.cmake
+++ b/monitoring-server/cmake/Testing.cmake
@@ -1,0 +1,7 @@
+
+option(ENABLE_TESTING "Enable testing" TRUE)
+
+if (ENABLE_TESTING)
+    enable_testing()
+    find_package(Catch2 REQUIRED)
+endif()

--- a/monitoring-server/libs/bme680/CMakeLists.txt
+++ b/monitoring-server/libs/bme680/CMakeLists.txt
@@ -16,3 +16,5 @@ set_target_properties(BME680 PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(BME680 PUBLIC include)
 
 target_include_directories(docs INTERFACE include)
+
+add_subdirectory(tests)

--- a/monitoring-server/libs/bme680/tests/CMakeLists.txt
+++ b/monitoring-server/libs/bme680/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+if (ENABLE_TESTING)
+    add_executable(BME680_tests)
+
+    set_target_properties(BME680_tests PROPERTIES LINKER_LANGUAGE CXX)
+
+    target_link_libraries(BME680_tests
+            PRIVATE
+            Catch2::Catch2
+            BME680)
+
+    add_test(NAME BME680Tests COMMAND BME680_tests)
+endif()

--- a/monitoring-server/libs/si1145/CMakeLists.txt
+++ b/monitoring-server/libs/si1145/CMakeLists.txt
@@ -16,3 +16,5 @@ set_target_properties(SI1145 PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(SI1145 PUBLIC include)
 
 target_include_directories(docs INTERFACE include)
+
+add_subdirectory(tests)

--- a/monitoring-server/libs/si1145/tests/CMakeLists.txt
+++ b/monitoring-server/libs/si1145/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+if (ENABLE_TESTING)
+    add_executable(SI1145_tests)
+
+    set_target_properties(SI1145_tests PROPERTIES LINKER_LANGUAGE CXX)
+
+    target_link_libraries(SI1145_tests
+            PRIVATE
+            Catch2::Catch2
+            SI1145)
+
+    add_test(NAME SI1145Tests COMMAND SI1145_tests)
+endif()

--- a/monitoring-server/libs/sn-gcja5/CMakeLists.txt
+++ b/monitoring-server/libs/sn-gcja5/CMakeLists.txt
@@ -16,3 +16,5 @@ set_target_properties(SN-GCJA5 PROPERTIES LINKER_LANGUAGE CXX)
 target_include_directories(SN-GCJA5 PUBLIC include)
 
 target_include_directories(docs INTERFACE include)
+
+add_subdirectory(tests)

--- a/monitoring-server/libs/sn-gcja5/tests/CMakeLists.txt
+++ b/monitoring-server/libs/sn-gcja5/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+if (ENABLE_TESTING)
+    add_executable(SN-GCJA5_tests)
+
+    set_target_properties(SN-GCJA5_tests PROPERTIES LINKER_LANGUAGE CXX)
+
+    target_link_libraries(SN-GCJA5_tests
+            PRIVATE
+            Catch2::Catch2
+            SN-GCJA5)
+
+    add_test(NAME SN-GCJA5Tests COMMAND SN-GCJA5_tests)
+endif()

--- a/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
+++ b/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
@@ -16,3 +16,16 @@ target_link_libraries(healthyhome-rpi
 target_include_directories(healthyhome-rpi PUBLIC include)
 
 target_include_directories(docs INTERFACE include)
+
+if (ENABLE_TESTING)
+    add_executable(healthyhome-rpi_tests)
+
+    set_target_properties(healthyhome-rpi_tests PROPERTIES LINKER_LANGUAGE CXX)
+
+    target_link_libraries(healthyhome-rpi_tests
+            PRIVATE
+            Catch2::Catch2
+            Core)
+
+    add_test(NAME HealthyHomeRpiTests COMMAND healthyhome-rpi_tests)
+endif()

--- a/monitoring-server/tests/CMakeLists.txt
+++ b/monitoring-server/tests/CMakeLists.txt
@@ -1,0 +1,12 @@
+if (ENABLE_TESTING)
+    add_executable(Core_tests)
+
+    set_target_properties(Core_tests PROPERTIES LINKER_LANGUAGE CXX)
+
+    target_link_libraries(Core_tests
+            PRIVATE
+            Catch2::Catch2
+            Core)
+
+    add_test(NAME CoreTests COMMAND Core_tests)
+endif()


### PR DESCRIPTION
This commit adds support to CMake for unit testing using the library Catch2.