### PR TITLE
Implement sn-gcja5 for monitoring server

### DIFF
--- a/monitoring-server/include/core/Server.h
+++ b/monitoring-server/include/core/Server.h
@@ -172,6 +172,9 @@ public:
         Message::Identity identity,
         Message::Factory factory);
 
+    /**
+     * @brief Destructor
+     */
     ~Server();
     /**
      * @}

--- a/monitoring-server/libs/sn-gcja5/CMakeLists.txt
+++ b/monitoring-server/libs/sn-gcja5/CMakeLists.txt
@@ -3,7 +3,20 @@ add_library(SN-GCJA5)
 
 target_sources(SN-GCJA5
         PUBLIC
-        include/sn-gcja5/Device.h)
+        include/sn-gcja5/defs.h
+        include/sn-gcja5/DensityPacket.h
+        include/sn-gcja5/Device.h
+        include/sn-gcja5/ParticleCountPacket.h
+        include/sn-gcja5/PM25Sensor.h
+        include/sn-gcja5/PM100Sensor.h
+        include/sn-gcja5/PMSensor.h
+        include/sn-gcja5/PM25Message.h
+        include/sn-gcja5/PM100Message.h
+        include/sn-gcja5/StatusMessage.h
+        include/sn-gcja5/StatusPacket.h
+
+        src/Device.cpp
+        src/PMSensor.cpp)
 
 target_link_libraries(SN-GCJA5
         PRIVATE

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/DensityPacket.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/DensityPacket.h
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/DensityPacket.h
+ */
+
+#ifndef SNGCJA5_DENSITY_PACKET_H
+#define SNGCJA5_DENSITY_PACKET_H
+
+#include <core/comms/Packet.h>
+#include <core/defs.h>
+#include <cstdint>
+#include <cstring>
+#include <sn-gcja5/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief I2C packet for reading density values from the sensor
+ * @headerfile sn-gcja5/DensityPacket.h <sn-gcja5/DensityPacket.h>
+ */
+struct DensityPacket : public Core::Comms::Packet {
+    float density = 0; ///< Density value
+
+    size_t getBufferSize() override
+    {
+        return sizeof density;
+    }
+
+    Core::StatusCode deserialize(const uint8_t* buffer) override
+    {
+        uint32_t num = 0;
+        std::memcpy(&num, buffer, sizeof density);
+        density = static_cast<float>(num) / MILLI;
+        return Core::SUCCESS;
+    }
+
+    Core::StatusCode serialize(uint8_t*) override
+    {
+        return Core::SUCCESS;
+    }
+};
+
+}
+
+#endif // SNGCJA5_DENSITY_PACKET_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/Device.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/Device.h
@@ -18,14 +18,18 @@
  */
 
 /**
- * @file sn-gcja5/Device.h
+ * @file libs/sn-gcja5/include/sn-gcja5/Device.h
  */
 
 #ifndef SNGCJA5_DEVICE_H
 #define SNGCJA5_DEVICE_H
 
 #include <core/Device.h>
+#include <core/Sensor.h>
+#include <core/Timer.h>
 #include <core/comms/I2C.h>
+#include <sn-gcja5/PM100Sensor.h>
+#include <sn-gcja5/PM25Sensor.h>
 
 /**
  * @brief Namespace for the Panasonic SN-GCJA5 library.
@@ -38,24 +42,32 @@ namespace SNGCJA5 {
 class Device : public Core::Device {
 public:
     /**
-     * @brief Configuration for the SN-GCJA5 Device.
-     */
-    struct Configuration {
-        Core::Comms::I2C* i2c; ///< Reference to an I2C implementation.
-    };
-
-    Device() = default;
-
-    /**
      * @brief Constructor for a SN-GCJA5 Device.
      * @param config configuration data structure.
      */
     explicit Device(Configuration config);
 
     const char* getName() override;
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unordered_map<std::string, Core::Sensor&> getSensors() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
 
 private:
     Configuration config;
+
+    Core::StatusCode readSensor();
+
+    std::unique_ptr<Core::Timer> timer;
+
+    SensorStatus sensorStatus;
+    PDLDStatus pdStatus;
+    PDLDStatus ldStatus;
+    FanStatus fanStatus;
+
+    PM25Sensor pm25;
+    PM100Sensor pm100;
 };
 
 }

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM100Message.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM100Message.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/PM100Message.h
+ */
+
+#ifndef SNGCJA5_PM100_MESSAGE_H
+#define SNGCJA5_PM100_MESSAGE_H
+
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Message carrying the PM10 sensor values
+ * @headerfile sn-gcja5/PM100Message.h <sn-gcja5/PM100Message.h>
+ */
+struct PM100Message : public Core::Message {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("pm100");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(PM100Message);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(PM100Message);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(PM100Message);
+
+    /**
+     * @brief Constructor
+     * @param _density PM10 density value
+     * @param _count PM10 count value
+     */
+    PM100Message(float _density, int _count) :
+        density(_density), particleCount(_count)
+    {
+    }
+
+    float density;     ///< Density value
+    int particleCount; ///< Particle count value
+};
+
+}
+
+#endif // SNGCJA5_PM100_MESSAGE_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM100Sensor.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM100Sensor.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file sn-gcja5/PM100Sensor.h
+ */
+
+#ifndef SNGCJA5_PM100_SENSOR_H
+#define SNGCJA5_PM100_SENSOR_H
+
+#include <sn-gcja5/PMSensor.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Performs I2C read of PM10 count and density from the sensor
+ * @headerfile sn-gcja5/PM100Sensor.h <sn-gcja5/PM100Sensor.h>
+ */
+class PM100Sensor : public PMSensor {
+public:
+    /**
+     * @brief Constructor
+     * @param _config SN-GCJA5 configuration
+     */
+    explicit PM100Sensor(Configuration& _config) :
+        PMSensor("pm100", _config, PM100_COUNT_CMD, PM100_DENSITY_CMD)
+    {
+    }
+};
+
+}
+
+#endif // SNGCJA5_PM100_SENSOR_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM25Message.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM25Message.h
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/PM25Message.h
+ */
+
+#ifndef SNGCJA5_PM25_MESSAGE_H
+#define SNGCJA5_PM25_MESSAGE_H
+
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Message carrying the PM2.5 sensor values
+ * @headerfile sn-gcja5/PM25Message.h <sn-gcja5/PM25Message.h>
+ */
+struct PM25Message : public Core::Message {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("pm25");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(PM25Message);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(PM25Message);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(PM25Message);
+
+    /**
+     * @brief Constructor
+     * @param _density PM2.5 density value
+     * @param _count PM2.5 count value
+     */
+    PM25Message(float _density, int _count) :
+        density(_density), particleCount(_count)
+    {
+    }
+
+    float density;     ///< Density value
+    int particleCount; ///< Particle count value
+};
+
+}
+
+#endif // SNGCJA5_PM25_MESSAGE_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM25Sensor.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PM25Sensor.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/PM25Sensor.h
+ */
+
+#ifndef SNGCJA5_PM25_SENSOR_H
+#define SNGCJA5_PM25_SENSOR_H
+
+#include <sn-gcja5/PMSensor.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Performs I2C read of PM2.5 count and density from the sensor
+ * @headerfile sn-gcja5/PM25Sensor.h <sn-gcja5/PM25Sensor.h>
+ */
+class PM25Sensor : public PMSensor {
+public:
+    /**
+     * @brief Constructor
+     * @param _config SN-GCJA5 configuration
+     */
+    explicit PM25Sensor(Configuration& _config) :
+        PMSensor("pm25", _config, PM25_COUNT_CMD, PM25_DENSITY_CMD)
+    {
+    }
+};
+
+}
+
+#endif // SNGCJA5_PM25_SENSOR_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PMSensor.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/PMSensor.h
@@ -1,0 +1,103 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/PMSensor.h
+ */
+
+#ifndef SNGCJA5_PM_SENSOR_H
+#define SNGCJA5_PM_SENSOR_H
+
+#include <core/Sensor.h>
+#include <cstdint>
+#include <sn-gcja5/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Generic Sensor class representing any PM sensor
+ * @headerfile sn-gcja5/PMSensor.h <sn-gcja5/PMSensor.h>
+ */
+class PMSensor : public Core::Sensor {
+public:
+    /**
+     * Constructor
+     * @param name name of the PM sensor
+     * @param _config SN-GCJA5 configuration
+     * @param _particleCountRegister register address for the particle count
+     * @param _densityRegister register address for the density
+     */
+    explicit PMSensor(
+        const char* name,
+        Configuration& _config,
+        uint8_t _particleCountRegister,
+        uint8_t _densityRegister) :
+        config(_config),
+        particleCountRegister(_particleCountRegister),
+        densityRegister(_densityRegister), sensorName(name)
+    {
+    }
+
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
+    const char* getName() override;
+
+    /**
+     * @brief Read values from the sensor
+     */
+    void read();
+
+    /**
+     * @brief Getter for the particle count
+     *
+     * @warning Use the getter after the values have been read,
+     *   otherwise it returns the last read value if any.
+     *
+     * @return particle count
+     */
+    uint16_t getParticleCount() const;
+
+    /**
+     * @brief Getter for the density
+     *
+     * @warning Use the getter after the values have been read,
+     *   otherwise it returns the last read value if any.
+     *
+     * @return density
+     */
+    float getDensity() const;
+
+private:
+    Configuration& config;
+    const uint8_t particleCountRegister;
+    const uint8_t densityRegister;
+    const char* sensorName;
+
+    uint16_t particleCount;
+    float density;
+};
+
+}
+
+#endif // SNGCJA5_PM_SENSOR_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/ParticleCountPacket.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/ParticleCountPacket.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/ParticleCountPacket.h
+ */
+
+#ifndef SNGCJA5_PARTICLE_COUNT_PACKET_H
+#define SNGCJA5_PARTICLE_COUNT_PACKET_H
+
+#include <core/defs.h>
+#include <cstdint>
+#include <cstring>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief I2C packet for reading count values from the sensor
+ * @headerfile sn-gcja5/ParticleCountPacket.h <sn-gcja5/ParticleCountPacket.h>
+ */
+struct ParticleCountPacket : public Core::Comms::Packet {
+    uint16_t count = 0; ///< Count value
+
+    size_t getBufferSize() override
+    {
+        return sizeof count;
+    }
+
+    Core::StatusCode deserialize(const uint8_t* buffer) override
+    {
+        std::memcpy(&count, buffer, sizeof count);
+        return Core::SUCCESS;
+    }
+
+    Core::StatusCode serialize(uint8_t*) override
+    {
+        return Core::SUCCESS;
+    }
+};
+
+}
+
+#endif // SNGCJA5_PARTICLE_COUNT_PACKET_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/StatusMessage.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/StatusMessage.h
@@ -1,0 +1,77 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/StatusMessage.h
+ */
+
+#ifndef SNGCJA5_STATUS_MESSAGE_H
+#define SNGCJA5_STATUS_MESSAGE_H
+
+#include <core/Device.h>
+#include <core/Message.h>
+#include <sn-gcja5/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief Message carrying the sensor status values
+ * @headerfile sn-gcja5/StatusMessage.h <sn-gcja5/StatusMessage.h>
+ */
+struct StatusMessage : public Core::Message {
+    /// Sets entity
+    SET_ENTITY = DEVICE_ENTITY("sn-gcja5");
+    /// Sets subject
+    SET_SUBJECT = "status";
+    /// Common Message codebase
+    MAKE_MESSAGE(StatusMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(StatusMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(StatusMessage);
+
+    /**
+     * @brief Constructor
+     * @param _sensor Sensor status value
+     * @param _pd PD status value
+     * @param _ld LD status value
+     * @param _fan Fan status value
+     */
+    StatusMessage(
+        SensorStatus _sensor,
+        PDLDStatus _pd,
+        PDLDStatus _ld,
+        FanStatus _fan) :
+        sensor(_sensor),
+        pd(_pd), ld(_ld), fan(_fan)
+    {
+    }
+
+    SensorStatus sensor; ///< Sensor status
+    PDLDStatus pd;       ///< PD status
+    PDLDStatus ld;       ///< LD status
+    FanStatus fan;       ///< Fan status
+};
+
+}
+
+#endif // SNGCJA5_STATUS_MESSAGE_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/StatusPacket.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/StatusPacket.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/StatusPacket.h
+ */
+
+#ifndef SNGCJA5_STATUS_PACKET_H
+#define SNGCJA5_STATUS_PACKET_H
+
+#include <core/defs.h>
+#include <cstdint>
+#include <sn-gcja5/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/**
+ * @brief I2C packet for reading sensor status
+ * @headerfile sn-gcja5/StatusPacket.h <sn-gcja5/StatusPacket.h>
+ */
+struct StatusPacket : public Core::Comms::Packet {
+    SensorStatus sensor; ///< Sensor status value
+    PDLDStatus pd;       ///< PD status value
+    PDLDStatus ld;       ///< LD status value
+    FanStatus fan;       ///< Fan status value
+
+    size_t getBufferSize() override
+    {
+        return sizeof(uint8_t);
+    }
+
+    Core::StatusCode deserialize(const uint8_t* buffer) override
+    {
+        sensor = static_cast<SensorStatus>((*buffer >> 6) & 3);
+        pd     = static_cast<PDLDStatus>((*buffer >> 4) & 3);
+        ld     = static_cast<PDLDStatus>((*buffer >> 2) & 3);
+        fan    = static_cast<FanStatus>(*buffer & 3);
+
+        return Core::SUCCESS;
+    }
+
+    Core::StatusCode serialize(uint8_t*) override
+    {
+        return Core::SUCCESS;
+    }
+};
+
+}
+
+#endif // SNGCJA5_STATUS_PACKET_H

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/defs.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/defs.h
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file libs/sn-gcja5/include/sn-gcja5/defs.h
+ * @headerfile sn-gcja5/defs.h <sn-gcja5/defs.h>
+ */
+
+#ifndef SNGCJA5_DEFS_H
+#define SNGCJA5_DEFS_H
+
+#include <core/Postman.h>
+#include <core/Timer.h>
+#include <core/comms/I2C.h>
+
+/**
+ * @brief Namespace for the Panasonic SN-GCJA5 library.
+ */
+namespace SNGCJA5 {
+
+/// Device I2C address constant
+constexpr uint8_t I2C_ADDR = 0x33;
+
+/// Sensor status register constant
+constexpr uint8_t STATUS_CMD = 0x26;
+
+/// PM2.5 density register address constant
+constexpr uint8_t PM25_DENSITY_CMD = 0x04;
+/// PM10 density register address constant
+constexpr uint8_t PM100_DENSITY_CMD = 0x08;
+
+/// PM2.5 count register address constant
+constexpr uint8_t PM25_COUNT_CMD = 0x10;
+/// PM10 count register address constant
+constexpr uint8_t PM100_COUNT_CMD = 0x18;
+
+/// Constant for a thousand, used for density correction.
+constexpr float MILLI = 1000;
+
+/// Timer interval (in ms) for reading the sensor values.
+constexpr int TIMER_INTERVAL = 1000;
+
+/**
+ * @brief Enumerator for the PDLD status.
+ */
+enum PDLDStatus {
+    NORMAL      = 0, ///< Normal status
+    NORMAL_SW   = 1, ///< Normal status, with S/W correction
+    ABNORMAL    = 2, ///< Abnormal status, loss of function
+    ABNORMAL_SW = 3, ///< Abnormal status, with S/W correction
+};
+
+/**
+ * @brief Enumerator for the sensor status.
+ */
+enum SensorStatus {
+    NO_OPERATION = 0, ///< No operation
+    FAN_ON       = 1, ///< Fan operating
+    LD_FAN_ON    = 2, ///< LD operating
+    PD_LD_FAN_ON = 3, ///< PD operating
+};
+
+/**
+ * @brief Enumerator for the fan status.
+ */
+enum FanStatus {
+    NORM        = 0, ///< Normal status
+    NORM_SW     = 1, ///< Normal status (1,000rpm or more), with S/W correction
+    CALIBRATION = 2, ///< In initial calibration
+    ABNORM      = 3, ///< Abnormal (below 1,000rpm), out of control
+};
+
+/**
+ * @brief Configuration for the SN-GCJA5 Device.
+ */
+struct Configuration {
+    Core::Comms::I2C& i2c;          ///< Reference to an I2C implementation.
+    Core::Timer::Factory makeTimer; ///< Timer factory.
+    Core::Postman& postman;         ///< Reference to the postman.
+};
+
+}
+
+#endif // SNGCJA5_DEFS_H

--- a/monitoring-server/libs/sn-gcja5/src/Device.cpp
+++ b/monitoring-server/libs/sn-gcja5/src/Device.cpp
@@ -1,0 +1,104 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bitset>
+#include <core/comms/I2C.h>
+#include <core/exceptions.h>
+#include <sn-gcja5/Device.h>
+#include <sn-gcja5/PM100Message.h>
+#include <sn-gcja5/PM25Message.h>
+#include <sn-gcja5/StatusMessage.h>
+#include <sn-gcja5/StatusPacket.h>
+
+using namespace SNGCJA5;
+
+// Sets up a timer for the sensor
+Core::StatusCode Device::setup()
+{
+    config.postman.registerMessageFactory(
+        StatusMessage::IDENTITY,
+        StatusMessage::factory);
+
+    timer = config.makeTimer();
+    timer->setInterval(TIMER_INTERVAL);
+    timer->setCallback(std::bind(&Device::readSensor, this));
+    return timer->setup();
+}
+
+// Reads data from the sensor's registers
+Core::StatusCode Device::readSensor()
+{
+    StatusPacket pck;
+    config.i2c.read(I2C_ADDR, STATUS_CMD, pck);
+
+    sensorStatus = pck.sensor;
+    ldStatus     = pck.ld;
+    pdStatus     = pck.pd;
+    fanStatus    = pck.fan;
+
+    pm25.read();
+    pm100.read();
+
+    PM25Message pm25msg { pm25.getDensity(), pm25.getParticleCount() };
+    config.postman.advertise(pm25msg);
+
+    PM100Message pm100msg { pm100.getDensity(), pm100.getParticleCount() };
+    config.postman.advertise(pm100msg);
+
+    return Core::SUCCESS;
+}
+
+Core::StatusCode Device::halt()
+{
+    return Core::SUCCESS;
+}
+
+std::unordered_map<std::string, Core::Sensor&> Device::getSensors()
+{
+    return {
+        { "pm25", pm25 },
+        { "pm100", pm100 },
+    };
+}
+
+Device::Device(Configuration _config) :
+    config(std::move(_config)), pm25({ config }), pm100({ config })
+{
+}
+
+const char* Device::getName()
+{
+    return "sn-gcja5";
+}
+
+std::unique_ptr<Core::Message> Device::handleMessage(
+    std::unique_ptr<Core::Message> message)
+{
+    auto subject = message->getSubject();
+
+    if (subject == StatusMessage::SUBJECT) {
+        return std::make_unique<StatusMessage>(
+            sensorStatus,
+            pdStatus,
+            ldStatus,
+            fanStatus);
+    }
+
+    throw Core::Exception::NotFound { "the requested entity was not found" };
+}

--- a/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
+++ b/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
@@ -1,0 +1,67 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <core/exceptions.h>
+#include <sn-gcja5/DensityPacket.h>
+#include <sn-gcja5/PMSensor.h>
+#include <sn-gcja5/ParticleCountPacket.h>
+
+using namespace SNGCJA5;
+
+void PMSensor::read()
+{
+    DensityPacket densityPacket;
+    ParticleCountPacket particlePacket;
+
+    config.i2c.read(I2C_ADDR, densityRegister, densityPacket);
+    config.i2c.read(I2C_ADDR, particleCountRegister, particlePacket);
+
+    density       = densityPacket.density;
+    particleCount = particlePacket.count;
+}
+
+Core::StatusCode PMSensor::setup()
+{
+    return Core::SUCCESS;
+}
+
+Core::StatusCode PMSensor::halt()
+{
+    return Core::SUCCESS;
+}
+
+const char* PMSensor::getName()
+{
+    return sensorName;
+}
+
+std::unique_ptr<Core::Message> PMSensor::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested message was not found" };
+}
+
+uint16_t PMSensor::getParticleCount() const
+{
+    return particleCount;
+}
+float PMSensor::getDensity() const
+{
+    return density;
+}

--- a/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
+++ b/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
@@ -4,14 +4,15 @@ target_sources(healthyhome-rpi
         PUBLIC
         src/messages/Devices.cpp
         src/messages/Sensors.cpp
+        src/messages/sn-gcja5/PM25Message.cpp
+        src/messages/sn-gcja5/PM100Message.cpp
+        src/messages/sn-gcja5/StatusMessage.cpp
         src/main.cpp)
 
 target_link_libraries(healthyhome-rpi
         PRIVATE
 
         Core
-        BME680
-        SI1145
         SN-GCJA5
         linux_i2c
         zmq_postman

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/PM100Message.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/PM100Message.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <sn-gcja5/PM100Message.h>
+#include <zmq-postman/Postman.h>
+
+using namespace SNGCJA5;
+
+static void serializer(const PM100Message& self, void* payload)
+{
+    auto* msgs = ZmqPostman::Postman::castPayload(payload);
+
+    msgs->emplace("particleCount", std::to_string(self.particleCount));
+    msgs->emplace("density", std::to_string(self.density));
+}
+
+static void deserializer(PM100Message&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    PM100Message::SERIALIZER   = serializer;
+    PM100Message::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/PM25Message.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/PM25Message.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <sn-gcja5/PM25Message.h>
+#include <zmq-postman/Postman.h>
+
+using namespace SNGCJA5;
+
+static void serializer(const PM25Message& self, void* payload)
+{
+    auto* msgs = ZmqPostman::Postman::castPayload(payload);
+    msgs->insert({ "particleCount", std::to_string(self.particleCount) });
+    msgs->insert({ "density", std::to_string(self.density) });
+}
+
+static void deserializer(PM25Message&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    PM25Message::SERIALIZER   = serializer;
+    PM25Message::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/StatusMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/sn-gcja5/StatusMessage.cpp
@@ -1,0 +1,48 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <core/exceptions.h>
+#include <sn-gcja5/StatusMessage.h>
+#include <zmq-postman/Postman.h>
+
+using namespace SNGCJA5;
+
+static void serializer(const StatusMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::Postman::castPayload(payload);
+
+    msgs->emplace("sensor", std::to_string(self.sensor));
+    msgs->emplace("ld", std::to_string(self.ld));
+    msgs->emplace("pd", std::to_string(self.pd));
+    msgs->emplace("fan", std::to_string(self.fan));
+}
+
+static void deserializer(StatusMessage&, const void* payload)
+{
+    auto* msgs = ZmqPostman::Postman::castPayload(payload);
+    if (msgs->size() != 0) {
+        throw Core::Exception::InvalidArgument { "invalid request body" };
+    }
+}
+
+static Core::StatusCode setup = [] {
+    StatusMessage::SERIALIZER   = serializer;
+    StatusMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();


### PR DESCRIPTION
This pull request implements the Panasonic sn-gcja5 library. Closes issues #28, #31.