### PR TITLE
Implement si1145 Sensor for the Monitoring Server

### DIFF
--- a/monitoring-server/cmake/CompilerWarnings.cmake
+++ b/monitoring-server/cmake/CompilerWarnings.cmake
@@ -43,7 +43,6 @@ function(set_project_warnings project_name)
             -Wunused # warn on anything being unused
             -Woverloaded-virtual # warn if you overload (not override) a virtual function
             -Wpedantic # warn if non-standard C++ is used
-            -Wconversion # warn on type conversions that may lose data
             -Wnull-dereference # warn if a null dereference is detected
             -Wdouble-promotion # warn if float is implicit promoted to double
             -Wformat=2 # warn on security issues around functions that format output (ie printf)

--- a/monitoring-server/cmake/Project.cmake
+++ b/monitoring-server/cmake/Project.cmake
@@ -5,6 +5,8 @@ target_sources(Core
         PUBLIC
         include/core/comms/I2C.h
         include/core/comms/Packet.h
+        include/core/comms/BytePacket.h
+        include/core/comms/WordPacket.h
         include/core/events/MessageDelivery.h
         include/core/events/StopServer.h
         include/core/events/TimerTrigger.h

--- a/monitoring-server/include/core/comms/BytePacket.h
+++ b/monitoring-server/include/core/comms/BytePacket.h
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file core/comms/BytePacket.h
+ */
+
+#ifndef CORE_BYTE_PACKET_H
+#define CORE_BYTE_PACKET_H
+
+#include <core/comms/Packet.h>
+#include <core/defs.h>
+
+namespace Core::Comms {
+
+/**
+ * @brief Packet representing a byte.
+ * @headerfile core/comms/BytePacket.h <core/comms/BytePacket.h>
+ */
+struct BytePacket : public Packet {
+    uint8_t value; ///< Value
+
+    /**
+     * @brief Constructor
+     */
+    BytePacket() = default;
+
+    /**
+     * @brief Constructor
+     * @param _value Value
+     */
+    explicit BytePacket(uint8_t _value) : value(_value) { }
+
+    size_t getBufferSize() override
+    {
+        return sizeof value;
+    }
+
+    StatusCode deserialize(const uint8_t* buffer) override
+    {
+        value = *buffer;
+        return SUCCESS;
+    }
+
+    StatusCode serialize(uint8_t* buffer) override
+    {
+        *buffer = value;
+        return SUCCESS;
+    }
+};
+
+}
+
+#endif // CORE_BYTE_PACKET_H

--- a/monitoring-server/include/core/comms/Packet.h
+++ b/monitoring-server/include/core/comms/Packet.h
@@ -25,6 +25,7 @@
 #define CORE_COMMS_PACKET_H
 
 #include <core/defs.h>
+#include <cstddef>
 #include <cstdint>
 
 namespace Core::Comms {

--- a/monitoring-server/include/core/comms/WordPacket.h
+++ b/monitoring-server/include/core/comms/WordPacket.h
@@ -1,0 +1,71 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file core/comms/WordPacket.h
+ */
+
+#ifndef CORE_WORD_PACKET_H
+#define CORE_WORD_PACKET_H
+
+#include <core/comms/Packet.h>
+#include <core/defs.h>
+#include <cstring>
+
+namespace Core::Comms {
+
+/**
+ * @brief Packet representing a word.
+ * @headerfile core/comms/WordPacket.h <core/comms/WordPacket.h>
+ */
+struct WordPacket : public Packet {
+    uint16_t value; ///< Value
+
+    /**
+     * @brief Constructor
+     */
+    WordPacket() = default;
+
+    /**
+     * @brief Constructor
+     * @param _value Value
+     */
+    explicit WordPacket(uint16_t _value) : value(_value) { }
+
+    size_t getBufferSize() override
+    {
+        return sizeof value;
+    }
+
+    StatusCode deserialize(const uint8_t* buffer) override
+    {
+        memcpy(&value, buffer, getBufferSize());
+        return SUCCESS;
+    }
+
+    StatusCode serialize(uint8_t* buffer) override
+    {
+        memcpy(buffer, &value, getBufferSize());
+        return SUCCESS;
+    }
+};
+
+}
+
+#endif // CORE_WORD_PACKET_H

--- a/monitoring-server/libs/si1145/CMakeLists.txt
+++ b/monitoring-server/libs/si1145/CMakeLists.txt
@@ -3,7 +3,17 @@ add_library(SI1145)
 
 target_sources(SI1145
         PUBLIC
-        include/si1145/Device.h)
+        include/si1145/defs.h
+        include/si1145/Device.h
+        include/si1145/UVCoefficientPacket.h
+        include/si1145/UVMessage.h
+        include/si1145/UVSensor.h
+        include/si1145/VisibleMessage.h
+        include/si1145/VisibleSensor.h
+
+        src/Device.cpp
+        src/UVSensor.cpp
+        src/VisibleSensor.cpp)
 
 target_link_libraries(SI1145
         PRIVATE

--- a/monitoring-server/libs/si1145/include/si1145/Device.h
+++ b/monitoring-server/libs/si1145/include/si1145/Device.h
@@ -25,7 +25,11 @@
 #define SI1145_DEVICE_H
 
 #include <core/Device.h>
+#include <core/Sensor.h>
+#include <core/Timer.h>
 #include <core/comms/I2C.h>
+#include <si1145/UVSensor.h>
+#include <si1145/VisibleSensor.h>
 
 /**
  * @brief Namespace for the Silicon Labs SI1145 library.
@@ -33,19 +37,9 @@
 namespace SI1145 {
 /**
  * @brief Concrete class for the Silicon Labs SI1145 device.
- * @headerfile si1145/Device.h <si1145/Device.h>
  */
 class Device : public Core::Device {
 public:
-    /**
-     * @brief Configuration for the SI1145 Device.
-     */
-    struct Configuration {
-        Core::Comms::I2C* i2c; ///< Reference to an I2C implementation.
-    };
-
-    Device() = default;
-
     /**
      * @brief Constructor for a SI1145 Device.
      * @param config configuration data structure.
@@ -53,9 +47,34 @@ public:
     explicit Device(Configuration config);
 
     const char* getName() override;
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unordered_map<std::string, Core::Sensor&> getSensors() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
+
+    /**
+     * @brief Write parameter
+     * @param i2c Reference to the I2C API
+     * @param addr Parameter to write
+     * @param value Value to be written to the parameter
+     * @return value Current parameter value
+     */
+    static ParameterValue writeParameter(
+        Core::Comms::I2C& i2c,
+        Parameter addr,
+        ParameterValue value);
 
 private:
     Configuration config;
+
+    Core::StatusCode readSensor();
+    void reset();
+
+    std::unique_ptr<Core::Timer> timer;
+
+    UVSensor uv;
+    VisibleSensor vis;
 };
 
 }

--- a/monitoring-server/libs/si1145/include/si1145/UVCoefficientPacket.h
+++ b/monitoring-server/libs/si1145/include/si1145/UVCoefficientPacket.h
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/UVCoefficientPacket.h
+ */
+
+#ifndef SI1145_UV_COEFFICIENT_PACKET_H
+#define SI1145_UV_COEFFICIENT_PACKET_H
+
+#include <core/comms/Packet.h>
+#include <core/defs.h>
+#include <cstring>
+
+/**
+ * @brief Namespace for the Panasonic SI1145 library.
+ */
+namespace SI1145 {
+
+/**
+ * @brief Packet representing a UV coefficient.
+ * @headerfile si1145/UVCoefficientPacket.h <si1145/UVCoefficientPacket.h>
+ */
+struct UVCoefficientPacket : public Core::Comms::Packet {
+    uint32_t value; ///< UV coefficient values
+
+    /**
+     * @brief Constructor
+     * @param _value UV coefficient values
+     */
+    UVCoefficientPacket(uint32_t _value) : value(_value) { }
+
+    size_t getBufferSize() override
+    {
+        return sizeof value;
+    }
+
+    Core::StatusCode deserialize(const uint8_t* buffer) override
+    {
+        memcpy(&value, buffer, getBufferSize());
+        return Core::SUCCESS;
+    }
+
+    Core::StatusCode serialize(uint8_t* buffer) override
+    {
+        memcpy(buffer, &value, getBufferSize());
+        return Core::SUCCESS;
+    }
+};
+
+}
+
+#endif // SI1145_UV_COEFFICIENT_PACKET_H

--- a/monitoring-server/libs/si1145/include/si1145/UVMessage.h
+++ b/monitoring-server/libs/si1145/include/si1145/UVMessage.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/UVMessage.h
+ */
+
+#ifndef SI1145_UV_MESSAGE_H
+#define SI1145_UV_MESSAGE_H
+
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Panasonic SI1145 library.
+ */
+namespace SI1145 {
+
+/**
+ * @brief Message carrying the visible light values
+ * @headerfile si1145/UVMessage.h <si1145/UVMessage.h>
+ */
+struct UVMessage : public Core::Message {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("uv");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(UVMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(UVMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(UVMessage);
+
+    /**
+     * @brief Constructor
+     * @param _value UV index value
+     */
+    UVMessage(double _value) : value(_value) { }
+
+    double value; ///< UV index value
+};
+
+}
+
+#endif // SI1145_UV_MESSAGE_H

--- a/monitoring-server/libs/si1145/include/si1145/UVSensor.h
+++ b/monitoring-server/libs/si1145/include/si1145/UVSensor.h
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/UVSensor.h
+ */
+#ifndef SI1145_UV_SENSOR_H
+#define SI1145_UV_SENSOR_H
+
+#include <core/Sensor.h>
+#include <si1145/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SI1145 library.
+ * @headerfile si1145/UVSensor.h <si1145/UVSensor.h>
+ */
+namespace SI1145 {
+
+/**
+ * @brief Sensor class representing the visible sensor
+ * @headerfile si1145/UVSensor.h <si1145/UVSensor.h>
+ */
+class UVSensor : public Core::Sensor {
+    double value;
+    Configuration& config;
+
+public:
+    /**
+     * @brief Constructor
+     * @param _config SI1145 configuration
+     */
+    explicit UVSensor(Configuration& _config) : config(_config) { }
+
+    /**
+     * @brief Getter for the UV index reading
+     *
+     * @warning Use the getter after the values have been read,
+     * otherwise it returns the last read value if any.
+     *
+     * @return UV index
+     */
+    double getValue() const;
+
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
+    const char* getName() override;
+
+    /**
+     * @brief Read values from the sensor
+     */
+    void read();
+};
+
+}
+
+#endif // SI1145_UV_SENSOR_H

--- a/monitoring-server/libs/si1145/include/si1145/VisibleMessage.h
+++ b/monitoring-server/libs/si1145/include/si1145/VisibleMessage.h
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/VisibleMessage.h
+ */
+
+#ifndef SI1145_VISIBLE_MESSAGE_H
+#define SI1145_VISIBLE_MESSAGE_H
+
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Panasonic SI1145 library.
+ */
+namespace SI1145 {
+
+/**
+ * @brief Message carrying the visible light values
+ * @headerfile si1145/VisibleMessage.h <si1145/VisibleMessage.h>
+ */
+struct VisibleMessage : public Core::Message {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("visible");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(VisibleMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(VisibleMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(VisibleMessage);
+
+    /**
+     * @brief Constructor
+     * @param _value Visible light value
+     */
+    VisibleMessage(uint16_t _value) : value(_value) { }
+
+    uint16_t value; ///< Visible light value
+};
+
+}
+
+#endif // SI1145_VISIBLE_MESSAGE_H

--- a/monitoring-server/libs/si1145/include/si1145/VisibleSensor.h
+++ b/monitoring-server/libs/si1145/include/si1145/VisibleSensor.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/UVSensor.h
+ */
+#ifndef SI1145_VISIBLE_SENSOR_H
+#define SI1145_VISIBLE_SENSOR_H
+
+#include <core/Sensor.h>
+#include <si1145/defs.h>
+
+/**
+ * @brief Namespace for the Panasonic SI1145 library.
+ */
+namespace SI1145 {
+
+/**
+ * @brief Sensor class representing the visible sensor
+ * @headerfile si1145/VisibleSensor.h <si1145/VisibleSensor.h>
+ */
+class VisibleSensor : public Core::Sensor {
+    uint16_t value;
+    Configuration& config;
+
+public:
+    /**
+     * @brief Constructor
+     * @param _config SI1145 configuration
+     */
+    explicit VisibleSensor(Configuration& _config) : config(_config) { }
+
+    /**
+     * @brief Getter for the visible light reading
+     *
+     * @warning Use the getter after the values have been read,
+     * otherwise it returns the last read value if any.
+     *
+     * @return visible light
+     */
+    uint16_t getValue() const;
+
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
+    const char* getName() override;
+
+    /**
+     * @brief Read values from the sensor
+     */
+    void read();
+};
+
+}
+
+#endif // SI1145_VISIBLE_SENSOR_H

--- a/monitoring-server/libs/si1145/include/si1145/defs.h
+++ b/monitoring-server/libs/si1145/include/si1145/defs.h
@@ -1,0 +1,171 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file si1145/defs.h
+ */
+
+#ifndef SI1145_DEFS_H
+#define SI1145_DEFS_H
+
+#include <core/Postman.h>
+#include <core/Timer.h>
+#include <core/comms/I2C.h>
+#include <cstdint>
+
+/**
+ * @brief Namespace for the Silicon Labs SI1145 library.
+ */
+namespace SI1145 {
+
+/// SI1145 device I2C Address
+constexpr uint8_t I2C_ADDR = 0x60;
+
+/// Interrupt configuration register address
+constexpr uint8_t INT_CONFIG_REG_ADDR = 0x03;
+
+/// Interrupt request enable register address
+constexpr uint8_t IRQ_ENABLE_REG_ADDR = 0x04;
+/// Interrupt request mode 1 register address
+constexpr uint8_t IRQ_MODE1_REG_ADDR = 0x05;
+/// Interrupt request mode 2 register address
+constexpr uint8_t IRQ_MODE2_REG_ADDR = 0x06;
+/// Interrupt request status register address
+constexpr uint8_t IRQ_STATUS_REG_ADDR = 0x21;
+
+/// HW Key register address
+constexpr uint8_t HW_KEY_REG_ADDR = 0x07;
+
+/**
+ * @name UV Coefficients
+ * @{
+ */
+
+/// UV coefficient address
+constexpr uint8_t UV_COEFF_ADDR = 0x13;
+/// UV coefficient value
+constexpr uint32_t UV_COEFF = 0x00'01'6B'7B;
+
+/**
+ * @}
+ *
+ * @name Commands
+ * @{
+ */
+
+/// Command register address
+constexpr uint8_t COMMAND_REG_ADDR = 0x18;
+
+/// Reset command
+constexpr uint8_t COMMAND_RESET = 0x01;
+
+/// Automatic ambient light sensor command
+constexpr uint8_t COMMAND_ALS_AUTO = 0x0E;
+
+/**
+ * @}
+ *
+ * @name Data registers
+ * @{
+ */
+
+/// Ambient light sensor visible light data register address
+constexpr uint8_t ALSVISDATA_REG_ADDR = 0x22;
+
+/// UV index data register address
+constexpr uint8_t UVINDEX_REG_ADDR = 0x2C;
+
+/**
+ * @}
+ *
+ * @name SI1145 parameters
+ * @{
+ */
+
+/// Command 'parameter set' flag
+constexpr uint8_t PARAM_SET_FLAG = 0xA0;
+
+/// Parameter write register address
+constexpr uint8_t PARAM_WR_REG_ADDR = 0x17;
+/// Parameter read register address
+constexpr uint8_t PARAM_RD_REG_ADDR = 0x2E;
+
+/// SI1145 parameters enumeration
+enum Parameter : uint8_t {
+    /// Sensor channel list parameter
+    CHANNEL_LIST = 0x01,
+    /// Ambient Light sensor visible light diode ADC recovery period parameter
+    ALS_VIS_ADC_COUNTER = 0x10,
+    /// Ambient light sensor visible light diode ADC gain parameter
+    ALS_VIS_ADC_GAIN = 0x11,
+    /// Ambient light sensor visible light diode ADC range parameter
+    ALS_VIS_ADC_RANGE = 0x12,
+};
+
+/// Parameter value type
+using ParameterValue = uint8_t;
+
+/// Channel list parameter value flags enumeration
+enum ChannelList : ParameterValue {
+    /// Enable UV sensor flag
+    ENABLE_UV = 0x80,
+    /// Enable ambient light sensor visible light flag
+    ENABLE_ALS_VISIBLE = 0x10,
+};
+
+/**
+ * @}
+ *
+ * @name Measurement rates
+ * @{
+ */
+
+/// Measurement rate LSB address
+constexpr uint8_t MEASRATE_REG_ADDR = 0x08;
+
+/**
+ * @brief Measurement rate
+ * Measurement rate in seconds divided by 31.25uS.
+ */
+constexpr uint16_t MEASRATE = 0x3E80; // 16,000 * 31.25uS = 500ms
+
+/**
+ * @}
+ */
+
+/// Gain for visible light ADC
+constexpr uint8_t GAIN = 4;
+/// Gain mask for visible light ADC
+constexpr uint8_t GAIN_MASK = 0b111;
+
+/// Timer interval (in ms) for reading the sensor values.
+constexpr int TIMER_INTERVAL = 500;
+
+/**
+ * @brief Configuration for the SI1145 Device.
+ */
+struct Configuration {
+    Core::Comms::I2C& i2c;          ///< Reference to an I2C implementation.
+    Core::Timer::Factory makeTimer; ///< Timer factory.
+    Core::Postman& postman;         ///< Reference to the postman.
+};
+
+}
+
+#endif // SI1145_DEFS_H

--- a/monitoring-server/libs/si1145/src/Device.cpp
+++ b/monitoring-server/libs/si1145/src/Device.cpp
@@ -1,0 +1,137 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bitset>
+#include <core/comms/BytePacket.h>
+#include <core/comms/I2C.h>
+#include <core/comms/WordPacket.h>
+#include <core/exceptions.h>
+#include <functional>
+#include <si1145/Device.h>
+#include <si1145/UVMessage.h>
+#include <si1145/VisibleMessage.h>
+#include <unistd.h>
+
+using namespace SI1145;
+
+ParameterValue Device::writeParameter(
+    Core::Comms::I2C& i2c,
+    Parameter addr,
+    ParameterValue value)
+{
+    Core::Comms::BytePacket pck;
+
+    // Write value to 'parameter write' register
+    pck.value = value;
+    i2c.write(I2C_ADDR, PARAM_WR_REG_ADDR, pck);
+
+    // Write parameter with 'parameter set' flag set to command register
+    pck.value = addr | PARAM_SET_FLAG;
+    i2c.write(I2C_ADDR, COMMAND_REG_ADDR, pck);
+
+    // Read value from 'parameter read' register
+    i2c.read(I2C_ADDR, PARAM_RD_REG_ADDR, pck);
+    return pck.value;
+}
+
+Core::StatusCode Device::setup()
+{
+    reset();
+
+    uv.setup();
+
+    writeParameter(config.i2c, CHANNEL_LIST, ENABLE_UV | ENABLE_ALS_VISIBLE);
+
+    vis.setup();
+
+    timer = config.makeTimer();
+    timer->setInterval(TIMER_INTERVAL);
+    timer->setCallback(std::bind(&Device::readSensor, this));
+    return timer->setup();
+
+    return Core::SUCCESS;
+}
+
+void Device::reset()
+{
+    Core::Comms::WordPacket pck { 0 };
+    config.i2c.write(I2C_ADDR, MEASRATE_REG_ADDR, pck);
+
+    Core::Comms::BytePacket pck2 { 0 };
+    config.i2c.write(I2C_ADDR, IRQ_ENABLE_REG_ADDR, pck2);
+    config.i2c.write(I2C_ADDR, IRQ_MODE1_REG_ADDR, pck2);
+    config.i2c.write(I2C_ADDR, IRQ_MODE2_REG_ADDR, pck2);
+
+    config.i2c.write(I2C_ADDR, INT_CONFIG_REG_ADDR, pck2);
+
+    pck2.value = 0xFF;
+    config.i2c.write(I2C_ADDR, IRQ_STATUS_REG_ADDR, pck2);
+
+    pck2.value = COMMAND_RESET;
+    config.i2c.write(I2C_ADDR, COMMAND_REG_ADDR, pck2);
+    usleep(25000);
+
+    pck2.value = 0x17;
+    config.i2c.write(I2C_ADDR, HW_KEY_REG_ADDR, pck2);
+    usleep(10000);
+}
+
+// Reads data from the sensor and performs required corrections to the raw data
+Core::StatusCode Device::readSensor()
+{
+    uv.read();
+    vis.read();
+
+    UVMessage uvmsg { uv.getValue() };
+    config.postman.advertise(uvmsg);
+
+    VisibleMessage visiblemsg { vis.getValue() };
+    config.postman.advertise(visiblemsg);
+
+    return Core::SUCCESS;
+}
+
+Core::StatusCode Device::halt()
+{
+    return Core::SUCCESS;
+}
+
+std::unordered_map<std::string, Core::Sensor&> Device::getSensors()
+{
+    return {
+        { "uv", uv },
+        { "visible", vis },
+    };
+}
+
+std::unique_ptr<Core::Message> Device::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested entity was not found" };
+}
+
+Device::Device(Configuration _config) :
+    config(std::move(_config)), uv({ config }), vis({ config })
+{
+}
+
+const char* Device::getName()
+{
+    return "si1145";
+}

--- a/monitoring-server/libs/si1145/src/UVSensor.cpp
+++ b/monitoring-server/libs/si1145/src/UVSensor.cpp
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <core/comms/BytePacket.h>
+#include <core/comms/WordPacket.h>
+#include <core/exceptions.h>
+#include <si1145/UVCoefficientPacket.h>
+#include <si1145/UVSensor.h>
+
+using namespace SI1145;
+using Core::Comms::BytePacket;
+
+void UVSensor::read()
+{
+    Core::Comms::WordPacket pck;
+    config.i2c.read(I2C_ADDR, UVINDEX_REG_ADDR, pck);
+    value = pck.value / 100.0;
+}
+
+Core::StatusCode UVSensor::setup()
+{
+    UVCoefficientPacket pck { UV_COEFF };
+    config.i2c.write(I2C_ADDR, UV_COEFF_ADDR, pck);
+    return Core::SUCCESS;
+}
+
+Core::StatusCode UVSensor::halt()
+{
+    return Core::SUCCESS;
+}
+
+const char* UVSensor::getName()
+{
+    return "uv";
+}
+
+std::unique_ptr<Core::Message> UVSensor::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested message was not found" };
+}
+
+double UVSensor::getValue() const
+{
+    return value;
+}

--- a/monitoring-server/libs/si1145/src/VisibleSensor.cpp
+++ b/monitoring-server/libs/si1145/src/VisibleSensor.cpp
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <core/comms/BytePacket.h>
+#include <core/comms/WordPacket.h>
+#include <core/defs.h>
+#include <core/exceptions.h>
+#include <si1145/Device.h>
+
+using namespace SI1145;
+using Core::Comms::BytePacket;
+using Core::Comms::WordPacket;
+
+void VisibleSensor::read()
+{
+    WordPacket visible;
+
+    config.i2c.read(I2C_ADDR, ALSVISDATA_REG_ADDR, visible);
+
+    value = visible.value;
+}
+
+Core::StatusCode VisibleSensor::setup()
+{
+    Device::writeParameter(config.i2c, ALS_VIS_ADC_GAIN, GAIN);
+    Device::writeParameter(
+        config.i2c,
+        ALS_VIS_ADC_COUNTER,
+        ((~GAIN) & GAIN_MASK) << 4);
+
+    Device::writeParameter(config.i2c, ALS_VIS_ADC_RANGE, 0x00);
+
+    WordPacket pck { MEASRATE };
+    config.i2c.write(I2C_ADDR, MEASRATE_REG_ADDR, pck);
+    BytePacket pck2 { COMMAND_ALS_AUTO };
+    config.i2c.write(I2C_ADDR, COMMAND_REG_ADDR, pck2);
+
+    return Core::SUCCESS;
+}
+
+Core::StatusCode VisibleSensor::halt()
+{
+    return Core::SUCCESS;
+}
+
+const char* VisibleSensor::getName()
+{
+    return "visible";
+}
+
+std::unique_ptr<Core::Message> VisibleSensor::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested message was not found" };
+}
+
+uint16_t VisibleSensor::getValue() const
+{
+    return value;
+}

--- a/monitoring-server/libs/sn-gcja5/src/Device.cpp
+++ b/monitoring-server/libs/sn-gcja5/src/Device.cpp
@@ -44,7 +44,14 @@ Core::StatusCode Device::setup()
 // Reads data from the sensor's registers
 Core::StatusCode Device::readSensor()
 {
+    static int readingNo = 0;
+    if (readingNo < 8) {
+        readingNo++;
+        return Core::SUCCESS;
+    }
+
     StatusPacket pck;
+
     config.i2c.read(I2C_ADDR, STATUS_CMD, pck);
 
     sensorStatus = pck.sensor;

--- a/monitoring-server/libs/zmq-postman/CMakeLists.txt
+++ b/monitoring-server/libs/zmq-postman/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(cppzmq)
+find_package(cppzmq QUIET)
 
 add_library(zmq_postman)
 

--- a/monitoring-server/libs/zmq-postman/include/zmq-postman/MessageBody.h
+++ b/monitoring-server/libs/zmq-postman/include/zmq-postman/MessageBody.h
@@ -38,11 +38,11 @@ public:
      * @param value
      */
     void putTagged(std::string key, int value);
-    /// @copydoc putTagged(std::string ley, int value)
+    /// @copydoc putTagged(std::string key, int value)
     void putTagged(std::string key, float value);
-    /// @copydoc putTagged(std::string ley, int value)
+    /// @copydoc putTagged(std::string key, int value)
     void putTagged(std::string key, double value);
-    /// @copydoc putTagged(std::string ley, int value)
+    /// @copydoc putTagged(std::string key, int value)
     void putTagged(std::string key, bool value);
     /**
      * Put a new key-value pair in the body.
@@ -60,8 +60,9 @@ public:
      * @throws Core::Exception::InvalidArgument if no such member was found.
      */
     std::string get(const std::string& key) const;
+
     /**
-     * Fetch a value given a key and convert its type.
+     * Fetch a value given a key and convert its type to integer.
      * @param key
      * @return converted value if found
      * @throws Core::Exception::InvalidArgument if no such member was found.
@@ -69,11 +70,35 @@ public:
      * converted.
      */
     int getInteger(const std::string& key) const;
-    /// @copydoc getInteger(const std::string& key)
+
+    /**
+     * Fetch a value given a key and convert its type to float.
+     * @param key
+     * @return converted value if found
+     * @throws Core::Exception::InvalidArgument if no such member was found.
+     * @throws Core::Exception::InvalidArgument if the value could not be
+     * converted.
+     */
     float getFloat(const std::string& key) const;
-    /// @copydoc getInteger(const std::string& key)
+
+    /**
+     * Fetch a value given a key and convert its type to double.
+     * @param key
+     * @return converted value if found
+     * @throws Core::Exception::InvalidArgument if no such member was found.
+     * @throws Core::Exception::InvalidArgument if the value could not be
+     * converted.
+     */
     double getDouble(const std::string& key) const;
-    /// @copydoc getInteger(const std::string& key)
+
+    /**
+     * Fetch a value given a key and convert its type to boolean.
+     * @param key
+     * @return converted value if found
+     * @throws Core::Exception::InvalidArgument if no such member was found.
+     * @throws Core::Exception::InvalidArgument if the value could not be
+     * converted.
+     */
     bool getBoolean(const std::string& key) const;
 
     /**
@@ -89,7 +114,7 @@ public:
      * @brief Casts a ZeroMQ payload.
      */
     static const MessageBody* castPayload(const void* payload);
-    /// @copydoc MessageBody::castPayload(void *payload)
+    /// @copydoc MessageBody::castPayload(const void *payload)
     static MessageBody* castPayload(void* payload);
 };
 

--- a/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
+++ b/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
@@ -4,6 +4,8 @@ target_sources(healthyhome-rpi
         PUBLIC
         src/messages/Devices.cpp
         src/messages/Sensors.cpp
+        src/messages/si1145/UVMessage.cpp
+        src/messages/si1145/VisibleMessage.cpp
         src/messages/sn-gcja5/PM25Message.cpp
         src/messages/sn-gcja5/PM100Message.cpp
         src/messages/sn-gcja5/StatusMessage.cpp

--- a/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
+++ b/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
@@ -11,7 +11,7 @@ target_sources(healthyhome-rpi
 
 target_link_libraries(healthyhome-rpi
         PRIVATE
-
+        SI1145
         Core
         SN-GCJA5
         linux_i2c

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/si1145/UVMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/si1145/UVMessage.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <si1145/UVMessage.h>
+#include <zmq-postman/Postman.h>
+
+using namespace SI1145;
+
+static void serializer(const UVMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+}
+
+static void deserializer(UVMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    UVMessage::SERIALIZER   = serializer;
+    UVMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/si1145/VisibleMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/si1145/VisibleMessage.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <si1145/VisibleMessage.h>
+#include <zmq-postman/Postman.h>
+
+using namespace SI1145;
+
+static void serializer(const VisibleMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+}
+
+static void deserializer(VisibleMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    VisibleMessage::SERIALIZER   = serializer;
+    VisibleMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();


### PR DESCRIPTION
This PR implements the si1145 sensor's library for the monitoring server. It also fixes some issues and defines BytePacket and WordPacket. Closes #30 and #33