### PR TITLE
Implement BME680 to Monitoring Server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "monitoring-server/libs/event-queue/vendor/concurrentqueue"]
 	path = monitoring-server/libs/event-queue/vendor/concurrentqueue
 	url = https://github.com/cameron314/concurrentqueue.git
+[submodule "monitoring-server/libs/bme680/vendor/bme68x"]
+	path = monitoring-server/libs/bme680/vendor/bme68x
+	url = https://github.com/BoschSensortec/BME68x-Sensor-API

--- a/monitoring-server/CMakeLists.txt
+++ b/monitoring-server/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.13)
 
-project(MonitoringServer CXX)
+project(MonitoringServer CXX C)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)

--- a/monitoring-server/libs/bme680/CMakeLists.txt
+++ b/monitoring-server/libs/bme680/CMakeLists.txt
@@ -11,12 +11,23 @@ set_target_properties(bme68x PROPERTIES C_STANDARD 11)
 
 target_include_directories(bme68x PUBLIC vendor/bme68x)
 
-
 add_library(BME680)
 
 target_sources(BME680
         PUBLIC
-        include/bme680/Device.h)
+        include/bme680/AdapterPacket.h
+        include/bme680/BSECSensor.h
+        include/bme680/BSECSensorMessage.h
+        include/bme680/CO2eMessage.h
+        include/bme680/defs.h
+        include/bme680/Device.h
+        include/bme680/HumidityMessage.h
+        include/bme680/IAQMessage.h
+        include/bme680/TemperatureMessage.h
+        src/BSECSensor.cpp
+        src/Device.cpp)
+
+target_include_directories(BME680 PUBLIC include)
 
 target_link_libraries(BME680
         PUBLIC
@@ -29,8 +40,6 @@ target_link_libraries(BME680
         algobsec)
 
 set_target_properties(BME680 PROPERTIES LINKER_LANGUAGE CXX)
-
-target_include_directories(BME680 PUBLIC include)
 
 target_include_directories(docs INTERFACE include)
 

--- a/monitoring-server/libs/bme680/CMakeLists.txt
+++ b/monitoring-server/libs/bme680/CMakeLists.txt
@@ -1,3 +1,16 @@
+add_library(bme68x)
+
+target_sources(bme68x
+        PUBLIC
+        vendor/bme68x/bme68x_defs.h
+        vendor/bme68x/bme68x.h
+        vendor/bme68x/bme68x.c)
+
+set_target_properties(bme68x PROPERTIES LINKER_LANGUAGE C)
+set_target_properties(bme68x PROPERTIES C_STANDARD 11)
+
+target_include_directories(bme68x PUBLIC vendor/bme68x)
+
 
 add_library(BME680)
 
@@ -6,8 +19,9 @@ target_sources(BME680
         include/bme680/Device.h)
 
 target_link_libraries(BME680
-        PRIVATE
+        PUBLIC
         Core
+        bme68x
         project_warnings
         project_options)
 

--- a/monitoring-server/libs/bme680/CMakeLists.txt
+++ b/monitoring-server/libs/bme680/CMakeLists.txt
@@ -23,7 +23,10 @@ target_link_libraries(BME680
         Core
         bme68x
         project_warnings
-        project_options)
+        project_options
+        PRIVATE
+        m
+        algobsec)
 
 set_target_properties(BME680 PROPERTIES LINKER_LANGUAGE CXX)
 

--- a/monitoring-server/libs/bme680/include/bme680/AdapterPacket.h
+++ b/monitoring-server/libs/bme680/include/bme680/AdapterPacket.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/AdapterPacket.h
+ */
+
+#ifndef BME680_ADAPTER_PACKET_H
+#define BME680_ADAPTER_PACKET_H
+
+#include <core/comms/Packet.h>
+#include <core/defs.h>
+#include <cstdint>
+#include <cstring>
+
+namespace BME680 {
+
+/**
+ * @brief I2C packet which adapts Core::Comms::I2C for the bme68x library
+ * @headerfile bme680/AdapterPacket.h <bme680/AdapterPacket.h>
+ */
+struct AdapterPacket : public Core::Comms::Packet {
+    uint8_t* readBuffer;        ///< Read buffer
+    const uint8_t* writeBuffer; ///< Write buffer
+    size_t size;                ///< Size of the buffer
+
+    AdapterPacket(uint8_t* _buffer, size_t _size) :
+        readBuffer(_buffer), size(_size)
+    {
+    }
+
+    AdapterPacket(const uint8_t* _buffer, size_t _size) :
+        writeBuffer(_buffer), size(_size)
+    {
+    }
+
+    size_t getBufferSize() override
+    {
+        return size;
+    }
+
+    Core::StatusCode deserialize(const uint8_t* sourceBuffer) override
+    {
+        std::memcpy(readBuffer, sourceBuffer, size);
+        return Core::SUCCESS;
+    }
+
+    Core::StatusCode serialize(uint8_t* targetBuffer) override
+    {
+        std::memcpy(targetBuffer, writeBuffer, size);
+        return Core::SUCCESS;
+    }
+};
+
+}
+
+#endif // BME680_ADAPTER_PACKET_H

--- a/monitoring-server/libs/bme680/include/bme680/BSECSensor.h
+++ b/monitoring-server/libs/bme680/include/bme680/BSECSensor.h
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/BSECSensor.h
+ */
+
+#ifndef BME680_BSEC_SENSOR_H
+#define BME680_BSEC_SENSOR_H
+
+#include <bme680/BSECSensorMessage.h>
+#include <bme680/defs.h>
+#include <core/Sensor.h>
+#include <cstdint>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Generic Sensor class representing any BSEC sensor
+ * @headerfile bme680/BSECSensor.h <bme680/BSECSensor.h>
+ */
+class BSECSensor : public Core::Sensor {
+public:
+    /**
+     * Constructor
+     * @param _name name of the BSEC sensor
+     */
+    explicit BSECSensor(const char* _name, BSECSensorMessage::Factory factory) :
+        name(_name), messageFactory(std::move(factory))
+    {
+    }
+
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
+    const char* getName() override;
+
+    void setValue(float value);
+    void setValueAccuracy(SensorValueAccuracy accuracy);
+
+    std::unique_ptr<Core::Message> generateMessage();
+
+private:
+    const char* name;
+    BSECSensorMessage::Factory messageFactory;
+
+    float value;
+    SensorValueAccuracy accuracy;
+};
+
+}
+
+#endif // BME680_BSEC_SENSOR_H

--- a/monitoring-server/libs/bme680/include/bme680/BSECSensorMessage.h
+++ b/monitoring-server/libs/bme680/include/bme680/BSECSensorMessage.h
@@ -1,0 +1,51 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/BSECSensorMessage.h
+ */
+
+#ifndef BME680_BSEC_SENSOR_MESSAGE_H
+#define BME680_BSEC_SENSOR_MESSAGE_H
+
+#include <bme680/defs.h>
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Message carrying the BSEC sensor values
+ * @headerfile bme680/BSECSensorMessage.h <bme680/BSECSensorMessage.h>
+ */
+struct BSECSensorMessage : public Core::Message {
+    using Factory = std::function<std::unique_ptr<BSECSensorMessage>()>;
+
+    BSECSensorMessage() = default;
+
+    float value;                  ///< Value
+    SensorValueAccuracy accuracy; ///< Accuracy
+};
+
+}
+
+#endif // BME680_BSEC_SENSOR_MESSAGE_H

--- a/monitoring-server/libs/bme680/include/bme680/CO2eMessage.h
+++ b/monitoring-server/libs/bme680/include/bme680/CO2eMessage.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/CO2eMessage.h
+ */
+
+#ifndef BME680_CO2E_MESSAGE_H
+#define BME680_CO2E_MESSAGE_H
+
+#include <bme680/BSECSensorMessage.h>
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Message carrying the CO2e sensor values
+ * @headerfile bme680/CO2eMessage.h <bme680/CO2eMessage.h>
+ */
+struct CO2eMessage : public BSECSensorMessage {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("co2e");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(CO2eMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(CO2eMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(CO2eMessage);
+
+    static std::unique_ptr<BSECSensorMessage> bsecSensorFactory()
+    {
+        return std::make_unique<CO2eMessage>();
+    }
+};
+
+}
+
+#endif // BME680_CO2E_MESSAGE_H

--- a/monitoring-server/libs/bme680/include/bme680/Device.h
+++ b/monitoring-server/libs/bme680/include/bme680/Device.h
@@ -24,28 +24,33 @@
 #ifndef BME680_DEVICE_H
 #define BME680_DEVICE_H
 
+extern "C" {
+#include <bme68x.h>
+}
+
+#include <bme680/BSECSensor.h>
+#include <bme680/CO2eMessage.h>
+#include <bme680/HumidityMessage.h>
+#include <bme680/IAQMessage.h>
+#include <bme680/TemperatureMessage.h>
+#include <bme680/defs.h>
+#include <bsec_interface.h>
 #include <core/Device.h>
+#include <core/Sensor.h>
+#include <core/Timer.h>
 #include <core/comms/I2C.h>
 
 /**
  * @brief Namespace for the Bosch Sensortec BME680 library.
  */
 namespace BME680 {
+
 /**
- * @brief Concrete class for the Bosch Sensortec BME680 device.
+ * @brief Concrete class for the BME680 device.
  * @headerfile bme680/Device.h <bme680/Device.h>
  */
 class Device : public Core::Device {
 public:
-    /**
-     * @brief Configuration for the BME680 Device.
-     */
-    struct Configuration {
-        Core::Comms::I2C* i2c; ///< Reference to an I2C implementation.
-    };
-
-    Device() = default;
-
     /**
      * @brief Constructor for a BME680 Device.
      * @param config configuration data structure.
@@ -53,9 +58,61 @@ public:
     explicit Device(Configuration config);
 
     const char* getName() override;
+    Core::StatusCode setup() override;
+    Core::StatusCode halt() override;
+    std::unordered_map<std::string, Core::Sensor&> getSensors() override;
+    std::unique_ptr<Core::Message> handleMessage(
+        std::unique_ptr<Core::Message> message) override;
 
 private:
     Configuration config;
+
+    BSECSensor tempSensor
+        = BSECSensor { "temp", &TemperatureMessage::bsecSensorFactory };
+    BSECSensor humSensor
+        = BSECSensor { "hum", &HumidityMessage::bsecSensorFactory };
+    BSECSensor iaqSensor = BSECSensor { "iaq", &IAQMessage::bsecSensorFactory };
+    BSECSensor co2eSensor
+        = BSECSensor { "co2e", &CO2eMessage::bsecSensorFactory };
+
+    Core::StatusCode triggerMeasurement();
+    Core::StatusCode waitUntilReady();
+    Core::StatusCode readNewData();
+    Core::StatusCode processData();
+    Core::StatusCode saveBSECState();
+
+    void addBSECInput(uint8_t sensorId, float signal);
+    int getNextCallTimeout();
+    Core::StatusCode nextStep(SensorState nextState, int timeout = 1);
+
+    static BME68X_INTF_RET_TYPE i2cWrite(
+        uint8_t reg_addr,
+        const uint8_t* reg_data,
+        uint32_t length,
+        void* intf_ptr);
+
+    static BME68X_INTF_RET_TYPE i2cRead(
+        uint8_t reg_addr,
+        uint8_t* reg_data,
+        uint32_t length,
+        void* intf_ptr);
+
+    uint8_t bsecState[BSEC_MAX_STATE_BLOB_SIZE];
+
+    bsec_input_t inputs[BSEC_MAX_PHYSICAL_SENSOR];
+    uint8_t inputsLength;
+
+    bsec_output_t outputs[BSEC_NUMBER_OUTPUTS];
+    uint8_t outputsLength;
+
+    std::unique_ptr<Core::Timer> timer;
+    bme68x_dev device;
+
+    bme68x_conf sensorConfiguration;
+    bsec_bme_settings_t desiredConfig;
+    int64_t lastTimestamp;
+
+    int unsavedSamples;
 };
 
 }

--- a/monitoring-server/libs/bme680/include/bme680/HumidityMessage.h
+++ b/monitoring-server/libs/bme680/include/bme680/HumidityMessage.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/HumidityMessage.h
+ */
+
+#ifndef BME680_HUMIDITY_MESSAGE_H
+#define BME680_HUMIDITY_MESSAGE_H
+
+#include <bme680/BSECSensorMessage.h>
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Message carrying the Humidity sensor values
+ * @headerfile bme680/HumidityMessage.h <bme680/HumidityMessage.h>
+ */
+struct HumidityMessage : public BSECSensorMessage {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("hum");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(HumidityMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(HumidityMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(HumidityMessage);
+
+    static std::unique_ptr<BSECSensorMessage> bsecSensorFactory()
+    {
+        return std::make_unique<HumidityMessage>();
+    }
+};
+
+}
+
+#endif // BME680_HUMIDITY_MESSAGE_H

--- a/monitoring-server/libs/bme680/include/bme680/IAQMessage.h
+++ b/monitoring-server/libs/bme680/include/bme680/IAQMessage.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/IAQMessage.h
+ */
+
+#ifndef BME680_IAQ_MESSAGE_H
+#define BME680_IAQ_MESSAGE_H
+
+#include <bme680/BSECSensorMessage.h>
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Message carrying the IAQ sensor values
+ * @headerfile bme680/IAQMessage.h <bme680/IAQMessage.h>
+ */
+struct IAQMessage : public BSECSensorMessage {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("iaq");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(IAQMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(IAQMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(IAQMessage);
+
+    static std::unique_ptr<BSECSensorMessage> bsecSensorFactory()
+    {
+        return std::make_unique<IAQMessage>();
+    }
+};
+
+}
+
+#endif // BME680_IAQ_MESSAGE_H

--- a/monitoring-server/libs/bme680/include/bme680/TemperatureMessage.h
+++ b/monitoring-server/libs/bme680/include/bme680/TemperatureMessage.h
@@ -1,0 +1,60 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/TemperatureMessage.h
+ */
+
+#ifndef BME680_TEMPERATURE_MESSAGE_H
+#define BME680_TEMPERATURE_MESSAGE_H
+
+#include <bme680/BSECSensorMessage.h>
+#include <core/Device.h>
+#include <core/Message.h>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Message carrying the Temperature sensor values
+ * @headerfile bme680/TemperatureMessage.h <bme680/TemperatureMessage.h>
+ */
+struct TemperatureMessage : public BSECSensorMessage {
+    /// Sets entity
+    SET_ENTITY = SENSOR_ENTITY("temp");
+    /// Sets subject
+    SET_SUBJECT = "update";
+    /// Common Message codebase
+    MAKE_MESSAGE(TemperatureMessage);
+    /// Static deserializer codebase
+    STATIC_DESERIALIZER(TemperatureMessage);
+    /// Static serializer codebase
+    STATIC_SERIALIZER(TemperatureMessage);
+
+    static std::unique_ptr<BSECSensorMessage> bsecSensorFactory()
+    {
+        return std::make_unique<TemperatureMessage>();
+    }
+};
+
+}
+
+#endif // BME680_TEMPERATURE_MESSAGE_H

--- a/monitoring-server/libs/bme680/include/bme680/defs.h
+++ b/monitoring-server/libs/bme680/include/bme680/defs.h
@@ -1,0 +1,150 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * @file bme680/defs.h
+ */
+
+#ifndef BME680_DEFS_H
+#define BME680_DEFS_H
+
+#include <bme68x_defs.h>
+#include <bsec_datatypes.h>
+#include <core/Postman.h>
+#include <core/Timer.h>
+#include <core/comms/I2C.h>
+#include <cstdint>
+
+/**
+ * @brief Namespace for the Bosch Sensortec BME680 library.
+ */
+namespace BME680 {
+
+/**
+ * @brief Enumerator for the BME680 device I2C addresses
+ */
+enum I2CAddress : uint8_t {
+    PRIMARY   = 0x76, ///< Primary I2C address
+    SECONDARY = 0x77, ///< Secondary I2C address
+};
+
+/// Timer interval (in ms) for reading the sensor values.
+constexpr float SAMPLE_RATE = BSEC_SAMPLE_RATE_LP;
+
+/// Forced operation mode command for the BME680
+constexpr uint8_t OPERATION_MODE = BME68X_FORCED_MODE;
+
+/// Interval (in ms) for waiting until sensor data is able to be read
+constexpr int WAIT_UNTIL_READY_INTERVAL = 5;
+
+/// Interval (in ms) for saving the sensor samples
+constexpr int SAVE_INTERVAL = 100;
+
+/// Number of virtual outputs from the BME680
+const uint8_t VIRTUAL_SENSORS_SIZE = 4;
+
+/// Configures the virtual outputs from the BME680
+const bsec_sensor_configuration_t VIRTUAL_SENSORS[VIRTUAL_SENSORS_SIZE]
+    = { {
+            SAMPLE_RATE,
+            BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE,
+        },
+        {
+            SAMPLE_RATE,
+            BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY,
+        },
+        { SAMPLE_RATE, BSEC_OUTPUT_IAQ },
+        {
+            SAMPLE_RATE,
+            BSEC_OUTPUT_CO2_EQUIVALENT,
+        } };
+
+/**
+ * @brief Enumerator for sensor states
+ */
+enum SensorState {
+    TRIGGER_MEASUREMENT, ///< Trigger measurement state
+    WAIT_UNTIL_READY,    ///< Wait until sensor is ready state
+    READ_NEW_DATA,       ///< Read new data state
+    PROCESS_DATA,        ///< Process data state
+    SAVE_STATE,          ///< Save state
+};
+
+/**
+ * @brief Enumerator for sensor value accuracies
+ */
+enum SensorValueAccuracy : uint8_t {
+    UNRELIABLE      = 0, ///< Sensor value is unreliable
+    LOW_ACCURACY    = 1, ///< Sensor value is of low accuracy
+    MEDIUM_ACCURACY = 2, ///< Sensor value is of medium accuracy
+    HIGH_ACCURACY   = 3, ///< Sensor value is of high accuracy
+};
+
+/**
+ * BSEC state load function pointer
+ * @param buffer buffer to load the state in
+ * @param bufferSize maximum size of the buffer
+ */
+using LoadBSECStateFnPtr
+    = std::function<size_t(uint8_t* buffer, size_t bufferSize)>;
+
+/**
+ * BSEC state save function pointer
+ * @param state array containing the state
+ * @param stateSize size of the state
+ */
+using SaveBSECStateFnPtr
+    = std::function<void(const uint8_t* state, size_t stateSize)>;
+
+/**
+ * Get timestamp in nanoseconds
+ * @return current timestamp in nanoseconds
+ */
+using GetTimestampFnPtr = std::function<int64_t()>;
+
+/**
+ * @brief Configuration for the BME680 Device.
+ */
+struct Configuration {
+    I2CAddress i2cAddr; ///< BME680 I2C address
+
+    float temperatureOffset; ///< Ambient temperature offset
+
+    uint8_t* bsecConfig;     ///< BSEC configuration
+    size_t bsecConfigLength; ///< BSEC configuration length
+
+    bme68x_delay_us_fptr_t delay_us; ///< Function pointer to a sleep function
+
+    /// Function pointer to a load state function
+    LoadBSECStateFnPtr loadBSECState;
+
+    /// Function pointer to a save state function
+    SaveBSECStateFnPtr saveBSECState;
+
+    /// Function pointer to a get timestamp function
+    GetTimestampFnPtr getTimestamp;
+
+    Core::Comms::I2C& i2c;          ///< Reference to an I2C implementation.
+    Core::Timer::Factory makeTimer; ///< Timer factory.
+    Core::Postman& postman;         ///< Reference to the postman.
+};
+
+}
+
+#endif // BME680_DEFS_H

--- a/monitoring-server/libs/bme680/src/BSECSensor.cpp
+++ b/monitoring-server/libs/bme680/src/BSECSensor.cpp
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/BSECSensor.h>
+#include <core/exceptions.h>
+
+using namespace BME680;
+
+Core::StatusCode BSECSensor::setup()
+{
+    return Core::SUCCESS;
+}
+
+Core::StatusCode BSECSensor::halt()
+{
+    return Core::SUCCESS;
+}
+
+const char* BSECSensor::getName()
+{
+    return name;
+}
+
+std::unique_ptr<Core::Message> BSECSensor::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested message was not found" };
+}
+
+void BSECSensor::setValue(float _value)
+{
+    value = _value;
+}
+
+void BSECSensor::setValueAccuracy(SensorValueAccuracy _accuracy)
+{
+    accuracy = _accuracy;
+}
+
+std::unique_ptr<Core::Message> BSECSensor::generateMessage()
+{
+    auto msg      = messageFactory();
+    msg->value    = value;
+    msg->accuracy = accuracy;
+    return msg;
+}

--- a/monitoring-server/libs/bme680/src/Device.cpp
+++ b/monitoring-server/libs/bme680/src/Device.cpp
@@ -1,0 +1,333 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/AdapterPacket.h>
+#include <bme680/BSECSensor.h>
+#include <bme680/Device.h>
+#include <core/exceptions.h>
+
+using namespace BME680;
+
+Core::StatusCode Device::setup()
+{
+    bsec_library_return_t bsec_status = BSEC_OK;
+
+    auto bme68x_res = bme68x_init(&device);
+    if (bme68x_res != BME68X_OK) {
+        return Core::E_GENERIC;
+    }
+
+    bsec_status = bsec_init();
+    if (bsec_status != BSEC_OK) {
+        return Core::E_GENERIC;
+    }
+
+    uint8_t workBuffer[BSEC_MAX_WORKBUFFER_SIZE] = { 0 };
+
+    if (config.bsecConfigLength != 0) {
+        bsec_status = bsec_set_configuration(
+            config.bsecConfig,
+            config.bsecConfigLength,
+            workBuffer,
+            BSEC_MAX_WORKBUFFER_SIZE);
+        if (bsec_status != BSEC_OK) {
+            return Core::E_GENERIC;
+        }
+    }
+
+    size_t bsecStateLength
+        = config.loadBSECState(bsecState, BSEC_MAX_STATE_BLOB_SIZE);
+    if (bsecStateLength != 0) {
+        bsec_status = bsec_set_state(
+            bsecState,
+            bsecStateLength,
+            workBuffer,
+            BSEC_MAX_WORKBUFFER_SIZE);
+        if (bsec_status != BSEC_OK) {
+            return Core::E_GENERIC;
+        }
+    }
+
+    bsec_sensor_configuration_t requiredSensors[BSEC_MAX_PHYSICAL_SENSOR];
+    uint8_t requiredSensorsSettings = BSEC_MAX_PHYSICAL_SENSOR;
+
+    bsec_status = bsec_update_subscription(
+        VIRTUAL_SENSORS,
+        VIRTUAL_SENSORS_SIZE,
+        requiredSensors,
+        &requiredSensorsSettings);
+    if (bsec_status != BSEC_OK) {
+        return Core::E_GENERIC;
+    }
+
+    unsavedSamples = 0;
+
+    timer = config.makeTimer();
+    return nextStep(TRIGGER_MEASUREMENT);
+}
+
+Core::StatusCode Device::triggerMeasurement()
+{
+    int waitTime  = 1;
+    lastTimestamp = config.getTimestamp();
+    // Fetch desired configuration by BSEC
+    bsec_sensor_control(lastTimestamp, &desiredConfig);
+
+    // Trigger measurement if requested
+    if (desiredConfig.trigger_measurement) {
+        bme68x_conf sensorConfig;
+        sensorConfig.os_temp = desiredConfig.temperature_oversampling;
+        sensorConfig.os_hum  = desiredConfig.humidity_oversampling;
+        sensorConfig.os_pres = desiredConfig.pressure_oversampling;
+        sensorConfig.filter  = BME68X_FILTER_OFF;
+        sensorConfig.odr     = BME68X_ODR_NONE;
+        bme68x_set_conf(&sensorConfig, &device);
+
+        bme68x_heatr_conf heaterConfig;
+        heaterConfig.enable     = desiredConfig.run_gas;
+        heaterConfig.heatr_temp = desiredConfig.heater_temperature;
+        heaterConfig.heatr_dur  = desiredConfig.heating_duration;
+        bme68x_set_heatr_conf(OPERATION_MODE, &heaterConfig, &device);
+
+        bme68x_set_op_mode(OPERATION_MODE, &device);
+
+        waitTime
+            = bme68x_get_meas_dur(OPERATION_MODE, &sensorConfig, &device) / 1e3;
+        if (waitTime < 1) {
+            waitTime = 1;
+        }
+    }
+
+    return nextStep(WAIT_UNTIL_READY, waitTime);
+}
+
+Core::StatusCode Device::waitUntilReady()
+{
+    uint8_t operationMode = OPERATION_MODE;
+
+    bme68x_get_op_mode(&operationMode, &device);
+
+    if (operationMode == OPERATION_MODE) {
+        return nextStep(WAIT_UNTIL_READY, WAIT_UNTIL_READY_INTERVAL);
+    }
+
+    if (desiredConfig.process_data) {
+        return nextStep(READ_NEW_DATA);
+    }
+
+    return nextStep(TRIGGER_MEASUREMENT, getNextCallTimeout());
+}
+
+Core::StatusCode Device::readNewData()
+{
+    inputsLength = 0;
+
+    uint8_t newData = 0;
+    bme68x_data sensorData;
+    bme68x_get_data(OPERATION_MODE, &sensorData, &newData, &device);
+
+    if (sensorData.status & BME68X_NEW_DATA_MSK) {
+        if (desiredConfig.process_data & BSEC_PROCESS_TEMPERATURE) {
+#ifdef BME68X_USE_FPU
+            addBSECInput(BSEC_INPUT_TEMPERATURE, sensorData.temperature);
+#else
+            addBSECInput(
+                BSEC_INPUT_TEMPERATURE,
+                sensorData.temperature / 100.0f);
+#endif
+            addBSECInput(BSEC_INPUT_HEATSOURCE, config.temperatureOffset);
+        }
+
+        if (desiredConfig.process_data & BSEC_PROCESS_HUMIDITY) {
+#ifdef BME68X_USE_FPU
+            addBSECInput(BSEC_INPUT_HUMIDITY, sensorData.humidity);
+#else
+            addBSECInput(BSEC_INPUT_HUMIDITY, sensorData.humidity / 1000.0f);
+#endif
+        }
+
+        if (desiredConfig.process_data & BSEC_PROCESS_PRESSURE) {
+            addBSECInput(BSEC_INPUT_PRESSURE, sensorData.pressure);
+        }
+
+        if ((desiredConfig.process_data & BSEC_PROCESS_GAS)
+            && (sensorData.status & BME68X_GASM_VALID_MSK)) {
+            addBSECInput(BSEC_INPUT_GASRESISTOR, sensorData.gas_resistance);
+        }
+
+        if (inputsLength > 0) {
+            return nextStep(PROCESS_DATA);
+        }
+    }
+
+    return nextStep(TRIGGER_MEASUREMENT, getNextCallTimeout());
+}
+
+Core::StatusCode Device::processData()
+{
+    outputsLength = BSEC_NUMBER_OUTPUTS;
+    bsec_do_steps(inputs, inputsLength, outputs, &outputsLength);
+
+    for (int idx = 0; idx < outputsLength; idx++) {
+        BSECSensor* sensor = nullptr;
+
+        switch (outputs[idx].sensor_id) {
+        case BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_TEMPERATURE:
+            sensor = &tempSensor;
+            break;
+        case BSEC_OUTPUT_SENSOR_HEAT_COMPENSATED_HUMIDITY:
+            sensor = &humSensor;
+            break;
+        case BSEC_OUTPUT_IAQ:
+            sensor = &iaqSensor;
+            break;
+        case BSEC_OUTPUT_CO2_EQUIVALENT:
+            sensor = &co2eSensor;
+            break;
+        default:
+            continue;
+        }
+
+        sensor->setValue(outputs[idx].signal);
+        sensor->setValueAccuracy(
+            static_cast<SensorValueAccuracy>(outputs[idx].accuracy));
+        auto msg = sensor->generateMessage();
+        config.postman.advertise(*msg);
+    }
+
+    if ((unsavedSamples++) > SAVE_INTERVAL) {
+        return nextStep(SAVE_STATE);
+    }
+
+    return nextStep(TRIGGER_MEASUREMENT, getNextCallTimeout());
+}
+
+void Device::addBSECInput(uint8_t sensorId, float signal)
+{
+    inputs[inputsLength].sensor_id  = sensorId;
+    inputs[inputsLength].signal     = signal;
+    inputs[inputsLength].time_stamp = lastTimestamp;
+    inputsLength++;
+}
+
+Core::StatusCode Device::saveBSECState()
+{
+    uint8_t workBuffer[BSEC_MAX_WORKBUFFER_SIZE] = { 0 };
+
+    uint32_t bsecStateLength = 0;
+    bsec_get_state(
+        0,
+        bsecState,
+        sizeof(bsecState),
+        workBuffer,
+        sizeof(workBuffer),
+        &bsecStateLength);
+
+    config.saveBSECState(bsecState, bsecStateLength);
+
+    unsavedSamples = 0;
+
+    return nextStep(TRIGGER_MEASUREMENT, getNextCallTimeout());
+}
+
+int Device::getNextCallTimeout()
+{
+    int sleepTime = (desiredConfig.next_call - config.getTimestamp()) / 1e6;
+    return sleepTime > 0 ? sleepTime : 1;
+}
+
+Core::StatusCode Device::nextStep(SensorState nextState, int timeout)
+{
+    timer->setInterval(timeout, true);
+
+    switch (nextState) {
+    case TRIGGER_MEASUREMENT:
+        timer->setCallback(std::bind(&Device::triggerMeasurement, this));
+        break;
+    case WAIT_UNTIL_READY:
+        timer->setCallback(std::bind(&Device::waitUntilReady, this));
+        break;
+    case READ_NEW_DATA:
+        timer->setCallback(std::bind(&Device::readNewData, this));
+        break;
+    case PROCESS_DATA:
+        timer->setCallback(std::bind(&Device::processData, this));
+        break;
+    case SAVE_STATE:
+        timer->setCallback(std::bind(&Device::saveBSECState, this));
+    }
+
+    return timer->setup();
+}
+
+Core::StatusCode Device::halt()
+{
+    return saveBSECState();
+}
+
+std::unordered_map<std::string, Core::Sensor&> Device::getSensors()
+{
+    return { { "temp", tempSensor },
+             { "hum", humSensor },
+             { "iaq", iaqSensor },
+             { "co2e", co2eSensor } };
+}
+
+std::unique_ptr<Core::Message> Device::handleMessage(
+    std::unique_ptr<Core::Message>)
+{
+    throw Core::Exception::NotFound { "the requested entity was not found" };
+}
+
+Device::Device(Configuration _config) : config(std::move(_config))
+{
+    device.intf     = BME68X_I2C_INTF;
+    device.intf_ptr = &config;
+    device.write    = Device::i2cWrite;
+    device.read     = Device::i2cRead;
+
+    device.delay_us = config.delay_us;
+}
+
+const char* Device::getName()
+{
+    return "bme680";
+}
+
+BME68X_INTF_RET_TYPE Device::i2cWrite(
+    uint8_t reg_addr,
+    const uint8_t* reg_data,
+    uint32_t length,
+    void* intf_ptr)
+{
+    auto* config = static_cast<Configuration*>(intf_ptr);
+    AdapterPacket pck { reg_data, length };
+    return config->i2c.write(config->i2cAddr, reg_addr, pck);
+}
+
+BME68X_INTF_RET_TYPE Device::i2cRead(
+    uint8_t reg_addr,
+    uint8_t* reg_data,
+    uint32_t length,
+    void* intf_ptr)
+{
+    auto* config = static_cast<Configuration*>(intf_ptr);
+    AdapterPacket pck { reg_data, length };
+    return config->i2c.read(config->i2cAddr, reg_addr, pck);
+}

--- a/monitoring-server/libs/sn-gcja5/include/sn-gcja5/defs.h
+++ b/monitoring-server/libs/sn-gcja5/include/sn-gcja5/defs.h
@@ -56,6 +56,12 @@ constexpr float MILLI = 1000;
 /// Timer interval (in ms) for reading the sensor values.
 constexpr int TIMER_INTERVAL = 1000;
 
+/// Filter value for density data
+constexpr float DENSITY_LIMIT = 100.0;
+
+/// Filter value for count data
+constexpr int COUNT_LIMIT = 30000;
+
 /**
  * @brief Enumerator for the PDLD status.
  */

--- a/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
+++ b/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
@@ -32,8 +32,13 @@ void PMSensor::read()
     config.i2c.read(I2C_ADDR, densityRegister, densityPacket);
     config.i2c.read(I2C_ADDR, particleCountRegister, particlePacket);
 
-    density       = densityPacket.density;
-    particleCount = particlePacket.count;
+    if (densityPacket.density < DENSITY_LIMIT) {
+        density = densityPacket.density;
+    }
+
+    if (particlePacket.count < COUNT_LIMIT) {
+        particleCount = particlePacket.count
+    }
 }
 
 Core::StatusCode PMSensor::setup()

--- a/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
+++ b/monitoring-server/platforms/healthyhome-rpi/CMakeLists.txt
@@ -2,17 +2,24 @@ add_executable(healthyhome-rpi)
 
 target_sources(healthyhome-rpi
         PUBLIC
+        include/bme680_defs.h
         src/messages/Devices.cpp
         src/messages/Sensors.cpp
+        src/messages/bme680/CO2eMessage.cpp
+        src/messages/bme680/HumidityMessage.cpp
+        src/messages/bme680/IAQMessage.cpp
+        src/messages/bme680/TemperatureMessage.cpp
         src/messages/si1145/UVMessage.cpp
         src/messages/si1145/VisibleMessage.cpp
         src/messages/sn-gcja5/PM25Message.cpp
         src/messages/sn-gcja5/PM100Message.cpp
         src/messages/sn-gcja5/StatusMessage.cpp
+        src/bme680_defs.cpp
         src/main.cpp)
 
 target_link_libraries(healthyhome-rpi
         PUBLIC
+        BME680
         SI1145
         Core
         SN-GCJA5

--- a/monitoring-server/platforms/healthyhome-rpi/include/bme680_defs.h
+++ b/monitoring-server/platforms/healthyhome-rpi/include/bme680_defs.h
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef HEALTHYHOME_RPI_BME680_DEFS_H
+#define HEALTHYHOME_RPI_BME680_DEFS_H
+
+#include <cstdint>
+
+#define BSEC_CONFIG_IAQ_LENGTH 454
+
+/// 3.3V 4 days calibration BSEC configuration parameters
+extern uint8_t bsec_config_iaq[BSEC_CONFIG_IAQ_LENGTH];
+
+/// load BSEC state function
+uint32_t loadState(uint8_t* state_buffer, uint32_t n_buffer);
+
+/// save BSEC state function
+void saveState(const uint8_t* state_buffer, uint32_t length);
+
+/// usleep wrapper for BME68x
+void delay_us(uint32_t time, void*);
+
+/// ns timestamp function for BSEC
+int64_t getTimestamp();
+
+#endif // HEALTHYHOME_RPI_BME680_DEFS_H

--- a/monitoring-server/platforms/healthyhome-rpi/src/bme680_defs.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/bme680_defs.cpp
@@ -1,0 +1,105 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680_defs.h>
+#include <fstream>
+#include <sys/time.h>
+#include <unistd.h>
+
+static const char* BSEC_STATE_FILE = "/var/lib/monitd/bsec.db";
+
+uint32_t loadState(uint8_t* state_buffer, uint32_t n_buffer)
+{
+    std::basic_ifstream<uint8_t> file(BSEC_STATE_FILE, std::ios::binary);
+
+    uint32_t res = 0;
+
+    if (file.is_open()) {
+        file.seekg(0, std::ios_base::end);
+        size_t length = file.tellg();
+        file.seekg(0, std::ios_base::beg);
+
+        if (length > n_buffer) {
+            file.close();
+            return res;
+        }
+
+        file.read(state_buffer, length);
+        file.close();
+    }
+
+    return res;
+}
+
+void saveState(const uint8_t* state_buffer, uint32_t length)
+{
+    std::ofstream file(BSEC_STATE_FILE, std::ios::binary | std::ios::trunc);
+
+    if (file.is_open()) {
+        file.write(reinterpret_cast<const char*>(state_buffer), length);
+        file.close();
+    }
+}
+
+void delay_us(uint32_t time, void*)
+{
+    usleep(time);
+}
+
+int64_t getTimestamp()
+{
+    timeval tv;
+    gettimeofday(&tv, nullptr);
+    return static_cast<int64_t>(tv.tv_sec) * 1e9
+           + static_cast<int64_t>(tv.tv_usec) * 1e3;
+}
+
+uint8_t bsec_config_iaq[BSEC_CONFIG_IAQ_LENGTH] = {
+    0,   8,   4,   1,   61,  0,   0,   0,   0,   0,   0,   0,   174, 1,   0,
+    0,   48,  0,   1,   0,   0,   192, 168, 71,  64,  49,  119, 76,  0,   0,
+    225, 68,  137, 65,  0,   191, 205, 204, 204, 190, 0,   0,   64,  191, 225,
+    122, 148, 190, 0,   0,   0,   0,   216, 85,  0,   100, 0,   0,   0,   0,
+    0,   0,   0,   0,   28,  0,   2,   0,   0,   244, 1,   225, 0,   25,  0,
+    0,   128, 64,  0,   0,   32,  65,  144, 1,   0,   0,   112, 65,  0,   0,
+    0,   63,  16,  0,   3,   0,   10,  215, 163, 60,  10,  215, 35,  59,  10,
+    215, 35,  59,  9,   0,   5,   0,   0,   0,   0,   0,   1,   88,  0,   9,
+    0,   229, 208, 34,  62,  0,   0,   0,   0,   0,   0,   0,   0,   218, 27,
+    156, 62,  225, 11,  67,  64,  0,   0,   160, 64,  0,   0,   0,   0,   0,
+    0,   0,   0,   94,  75,  72,  189, 93,  254, 159, 64,  66,  62,  160, 191,
+    0,   0,   0,   0,   0,   0,   0,   0,   33,  31,  180, 190, 138, 176, 97,
+    64,  65,  241, 99,  190, 0,   0,   0,   0,   0,   0,   0,   0,   167, 121,
+    71,  61,  165, 189, 41,  192, 184, 30,  189, 64,  12,  0,   10,  0,   0,
+    0,   0,   0,   0,   0,   0,   0,   229, 0,   254, 0,   2,   1,   5,   48,
+    117, 100, 0,   44,  1,   112, 23,  151, 7,   132, 3,   197, 0,   92,  4,
+    144, 1,   64,  1,   64,  1,   144, 1,   48,  117, 48,  117, 48,  117, 48,
+    117, 100, 0,   100, 0,   100, 0,   48,  117, 48,  117, 48,  117, 100, 0,
+    100, 0,   48,  117, 48,  117, 100, 0,   100, 0,   100, 0,   100, 0,   48,
+    117, 48,  117, 48,  117, 100, 0,   100, 0,   100, 0,   48,  117, 48,  117,
+    100, 0,   100, 0,   44,  1,   44,  1,   44,  1,   44,  1,   44,  1,   44,
+    1,   44,  1,   44,  1,   44,  1,   44,  1,   44,  1,   44,  1,   44,  1,
+    44,  1,   8,   7,   8,   7,   8,   7,   8,   7,   8,   7,   8,   7,   8,
+    7,   8,   7,   8,   7,   8,   7,   8,   7,   8,   7,   8,   7,   8,   7,
+    112, 23,  112, 23,  112, 23,  112, 23,  112, 23,  112, 23,  112, 23,  112,
+    23,  112, 23,  112, 23,  112, 23,  112, 23,  112, 23,  112, 23,  255, 255,
+    255, 255, 255, 255, 255, 255, 220, 5,   220, 5,   220, 5,   255, 255, 255,
+    255, 255, 255, 220, 5,   220, 5,   255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+    255, 255, 255, 255, 255, 255, 255, 255, 255, 44,  1,   0,   0,   0,   0,
+    237, 52,  0,   0
+};

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/CO2eMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/CO2eMessage.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/CO2eMessage.h>
+#include <iostream>
+#include <zmq-postman/Postman.h>
+
+using namespace BME680;
+
+static void serializer(const CO2eMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+    msgs->putTagged("accuracy", self.accuracy);
+}
+
+static void deserializer(CO2eMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    CO2eMessage::SERIALIZER   = serializer;
+    CO2eMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/HumidityMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/HumidityMessage.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/HumidityMessage.h>
+#include <iostream>
+#include <zmq-postman/Postman.h>
+
+using namespace BME680;
+
+static void serializer(const HumidityMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+}
+
+static void deserializer(HumidityMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    HumidityMessage::SERIALIZER   = serializer;
+    HumidityMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/IAQMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/IAQMessage.cpp
@@ -1,0 +1,39 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/IAQMessage.h>
+#include <iostream>
+#include <zmq-postman/Postman.h>
+
+using namespace BME680;
+
+static void serializer(const IAQMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+    msgs->putTagged("accuracy", self.accuracy);
+}
+
+static void deserializer(IAQMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    IAQMessage::SERIALIZER   = serializer;
+    IAQMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();

--- a/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/TemperatureMessage.cpp
+++ b/monitoring-server/platforms/healthyhome-rpi/src/messages/bme680/TemperatureMessage.cpp
@@ -1,0 +1,38 @@
+/*
+ * This file is part of the HealthyHome project monitoring server
+ * available at <https://www.github.com/healthyhomeuk/healthyhome>.
+ *
+ * Copyright (C) 2021 the authors of the HealthyHome project.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3 of the License.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <bme680/TemperatureMessage.h>
+#include <iostream>
+#include <zmq-postman/Postman.h>
+
+using namespace BME680;
+
+static void serializer(const TemperatureMessage& self, void* payload)
+{
+    auto* msgs = ZmqPostman::MessageBody::castPayload(payload);
+    msgs->putTagged("value", self.value);
+}
+
+static void deserializer(TemperatureMessage&, const void*) { }
+
+static Core::StatusCode setup = [] {
+    TemperatureMessage::SERIALIZER   = serializer;
+    TemperatureMessage::DESERIALIZER = deserializer;
+    return Core::SUCCESS;
+}();


### PR DESCRIPTION
This pull request implements the BME680 library for the Monitoring Server. It also implements a filter for the particle count and density values from the SN-GCJA5 sensor. Closes issues #29 and #32. 