### PR TITLE
monit/sn-gcja5: Fix syntax error

### DIFF
--- a/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
+++ b/monitoring-server/libs/sn-gcja5/src/PMSensor.cpp
@@ -37,7 +37,7 @@ void PMSensor::read()
     }
 
     if (particlePacket.count < COUNT_LIMIT) {
-        particleCount = particlePacket.count
+        particleCount = particlePacket.count;
     }
 }
 


### PR DESCRIPTION
This pull request implements a syntax error fix for the filter for the sn-gcja5